### PR TITLE
Adds info to readme on how to setup .eslintrc.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ npm install eslint-config-dwt
 ``` sh
 yarn add eslint-config-dwt
 ```
+
+After this is done you need to get the config-file in your root directory. Either manually copy or run the folling command in your project root:
+
+```sh 
+curl https://raw.githubusercontent.com/dwtechnologies/eslint-config-dwt/master/index.js >> .eslintrc.js
+```


### PR DESCRIPTION
Don't know if I understood it correctly but I think we need the config (available in `./index.js`) copied to our project root?

This is an attempt I did in my project which seemed to work fine. If this isn't the route we want to take, just kill the PR, no problem 😸 